### PR TITLE
[BE] 숙소 예약 페이지 GET API 수정

### DIFF
--- a/be/src/main/java/kr/codesquad/airbnb/domain/DiscountPolicy.java
+++ b/be/src/main/java/kr/codesquad/airbnb/domain/DiscountPolicy.java
@@ -1,5 +1,6 @@
 package kr.codesquad.airbnb.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
@@ -8,10 +9,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @NoArgsConstructor
+@Getter
 @Entity
 public class DiscountPolicy {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
     private double discountRate;
 
     public DiscountPolicy(double discountRate) {

--- a/be/src/main/java/kr/codesquad/airbnb/dto/ReserveFormResponseDto.java
+++ b/be/src/main/java/kr/codesquad/airbnb/dto/ReserveFormResponseDto.java
@@ -14,6 +14,7 @@ public class ReserveFormResponseDto {
     private int cleaningFee;
     private int adultChildCapacity;
     private int infantCapacity;
+    private double discountRate;
 
     public static ReserveFormResponseDto of(Accommodation accommodation) {
         return ReserveFormResponseDto.builder()
@@ -21,6 +22,7 @@ public class ReserveFormResponseDto {
             .cleaningFee(accommodation.getCleaningFee())
             .adultChildCapacity(accommodation.getAdultChildCapacity())
             .infantCapacity(accommodation.getInfantCapacity())
+            .discountRate(accommodation.getDiscountPolicy().getDiscountRate())
             .build();
     }
 }


### PR DESCRIPTION
### 📙 작업 내역

- [x] 기존 API 명세를 아래와 같이 수정함에 따라, 숙소 예약 페이지 GET API 수정
  - [x] `ReserveFormResponseDto` 에 할인 정책 관련 필드 추가
  - [x] DiscountPolicy 필드 타입 불일치 에러 수정 
![image](https://user-images.githubusercontent.com/91416897/171081358-e8a14771-fdd9-467d-9569-a0dd3ce19633.png)


### 📘 작업 유형

-  수정

### 📝 Issue 특이 사항

<br/><br/>