### PR TITLE
[BE] Feat: ReserveResponseDto 추가

### DIFF
--- a/be/src/main/java/kr/codesquad/airbnb/controller/AccommodationController.java
+++ b/be/src/main/java/kr/codesquad/airbnb/controller/AccommodationController.java
@@ -1,10 +1,8 @@
 package kr.codesquad.airbnb.controller;
 
 import java.util.List;
-import kr.codesquad.airbnb.dto.ReserveFormResponseDto;
-import kr.codesquad.airbnb.dto.ReserveRequestDto;
-import kr.codesquad.airbnb.dto.SearchQueryRequestDto;
-import kr.codesquad.airbnb.dto.SearchQueryResponseDto;
+
+import kr.codesquad.airbnb.dto.*;
 import kr.codesquad.airbnb.service.AccommodationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -41,8 +39,8 @@ public class AccommodationController {
     }
 
     @PostMapping("/{accommodationId}/reservation")
-    public ResponseEntity<Void> registerReservation(@RequestBody ReserveRequestDto requestDto, @PathVariable Long accommodationId) {
-           return new ResponseEntity<>(accommodationService.registerReservation(requestDto, accommodationId));
+    public ResponseEntity<ReserveResponseDto> registerReservation(@RequestBody ReserveRequestDto requestDto, @PathVariable Long accommodationId) {
+           return ResponseEntity.ok(accommodationService.registerReservation(requestDto, accommodationId));
     }
 
 }

--- a/be/src/main/java/kr/codesquad/airbnb/dto/ReserveResponseDto.java
+++ b/be/src/main/java/kr/codesquad/airbnb/dto/ReserveResponseDto.java
@@ -1,0 +1,12 @@
+package kr.codesquad.airbnb.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReserveResponseDto {
+    private int statusCode;
+    private String message;
+
+}

--- a/be/src/main/java/kr/codesquad/airbnb/service/AccommodationService.java
+++ b/be/src/main/java/kr/codesquad/airbnb/service/AccommodationService.java
@@ -8,10 +8,7 @@ import kr.codesquad.airbnb.domain.member.Member;
 import kr.codesquad.airbnb.domain.reservation.Reservation;
 import kr.codesquad.airbnb.domain.accommodation.AccommodationNotFoundException;
 import kr.codesquad.airbnb.domain.member.MemberNotFoundException;
-import kr.codesquad.airbnb.dto.ReserveFormResponseDto;
-import kr.codesquad.airbnb.dto.ReserveRequestDto;
-import kr.codesquad.airbnb.dto.SearchQueryRequestDto;
-import kr.codesquad.airbnb.dto.SearchQueryResponseDto;
+import kr.codesquad.airbnb.dto.*;
 import kr.codesquad.airbnb.repository.AccommodationRepository;
 import kr.codesquad.airbnb.repository.MemberRepository;
 import kr.codesquad.airbnb.repository.ReservationRepository;
@@ -51,7 +48,7 @@ public class AccommodationService {
         return ReserveFormResponseDto.of(accommodation);
     }
 
-    public HttpStatus registerReservation(ReserveRequestDto requestDto, Long accommodationId) {
+    public ReserveResponseDto registerReservation(ReserveRequestDto requestDto, Long accommodationId) {
         Member member = memberRepository.findById(requestDto.getUserId())
                 .orElseThrow(MemberNotFoundException::new);
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
@@ -69,6 +66,6 @@ public class AccommodationService {
                 .build();
 
         reservationRepository.save(reservation);
-        return HttpStatus.OK;
+        return new ReserveResponseDto(200, "예약 요청이 완료되었습니다.");
     }
 }


### PR DESCRIPTION
### 📙 작업 내역

- [x] 숙소 예약 API Response DTO 추가:
    숙소 예약 POST 요청 시 HTTP 응답 바디에 상태코드와 메시지를 출력하기 위한 DTO 추가.
이후 해당 DTO를 반환하도록 컨트롤러와 서비스 계층 로직 수정.

### 📘 작업 유형

- 신규 기능 추가

### 📝 Issue 특이 사항

<br/><br/>