### PR TITLE
[Fe] context의 hook 분리, 헤더 영역 밖 클릭 개선

### DIFF
--- a/fe/src/components/Calender/Day.tsx
+++ b/fe/src/components/Calender/Day.tsx
@@ -1,6 +1,8 @@
-import { usePeriodDispatch, usePeriodState } from 'contexts/periodContext';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
+
+import { usePeriodDispatch, usePeriodState } from 'hooks/usePeriod';
+
 import { mockDate } from 'utils/util';
 
 type DayProps = {

--- a/fe/src/components/Calender/index.tsx
+++ b/fe/src/components/Calender/index.tsx
@@ -1,9 +1,11 @@
-import { usePeriodDispatch } from 'contexts/periodContext';
+import styled from 'styled-components';
+import Day from 'components/Calender/Day';
+
 import { ReactComponent as LeftIcon } from 'images/FE_숙소예약서비스/Property 1=chevron-left.svg';
 import { ReactComponent as RightIcon } from 'images/FE_숙소예약서비스/Property 1=chevron-right.svg';
-import styled from 'styled-components';
+
+import { usePeriodDispatch } from 'hooks/usePeriod';
 import { getDays, keyMaker } from 'utils/util';
-import Day from './Day';
 
 type CalendarProps = {
   date: Date;

--- a/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
+++ b/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { Divider } from '@mui/material';
 import { StyledSearchIcon } from 'components/Header/SearchBar/searchBar.styled';
 
-import { usePersonnelState } from 'contexts/PersonnelContext';
 import { usePeriodDispatch, usePeriodState } from 'hooks/usePeriod';
+import { usePersonnelState } from 'hooks/usePersonnel';
 import { usePriceState } from 'hooks/usePrice';
 
 import { makeDateString, mockDate } from 'utils/util';

--- a/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
+++ b/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
@@ -1,12 +1,14 @@
+import { useEffect } from 'react';
+
 import styled from 'styled-components';
 import { Divider } from '@mui/material';
 import { StyledSearchIcon } from 'components/Header/SearchBar/searchBar.styled';
 
 import { usePersonnelState } from 'contexts/PersonnelContext';
+import { usePeriodDispatch, usePeriodState } from 'hooks/usePeriod';
 import { usePriceState } from 'hooks/usePrice';
-import { usePeriodDispatch, usePeriodState } from 'contexts/periodContext';
+
 import { makeDateString, mockDate } from 'utils/util';
-import { useEffect } from 'react';
 
 type MyProps = {
   changeSearchBar: (e: React.MouseEvent<HTMLElement>) => void;

--- a/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
+++ b/fe/src/components/Header/SearchBar/MiniSearchBar/index.tsx
@@ -16,7 +16,7 @@ function MiniSearchBar({ changeSearchBar }: MyProps) {
   const { personnelCounterText } = usePersonnelState();
   const { priceRangeText } = usePriceState();
   const { checkIn, checkOut, periodText } = usePeriodState();
-  const { setText } = usePeriodDispatch();
+  const { setPeriodText } = usePeriodDispatch();
   function makePeriodString() {
     const isCheckInState = checkIn.getTime() === mockDate.getTime();
     const isCheckOutState = checkOut.getTime() === mockDate.getTime();
@@ -24,7 +24,7 @@ function MiniSearchBar({ changeSearchBar }: MyProps) {
     if (!isCheckInState && !isCheckOutState) {
       const [checkInString, checkOutString] = [makeDateString(checkIn), makeDateString(checkOut)];
       const periodString = `${checkInString} ~ ${checkOutString}`;
-      setText(periodString);
+      setPeriodText(periodString);
     }
   }
   useEffect(() => {

--- a/fe/src/components/Header/SearchBar/Period.tsx
+++ b/fe/src/components/Header/SearchBar/Period.tsx
@@ -1,12 +1,13 @@
 import { Divider } from '@mui/material';
-import { CommonContainer } from 'components/Header/SearchBar/searchBar.styled';
-
-import { usePeriodDispatch, usePeriodState } from 'contexts/periodContext';
-import { makeDateString, mockDate } from 'utils/util';
 
 import { ClickModal } from 'components/Header/SearchBar/';
+import { CommonContainer } from 'components/Header/SearchBar/searchBar.styled';
 import InputButton from 'components/Header/SearchBar/common/InputButton';
 import ResetButton from 'components/Header/SearchBar/common/ResetButton';
+
+import { usePeriodDispatch, usePeriodState } from 'hooks/usePeriod';
+
+import { makeDateString, mockDate } from 'utils/util';
 
 function Period({ clickModal, isClicked, searchBarFocusModal }: ClickModal) {
   const { resetDate } = usePeriodDispatch();

--- a/fe/src/components/Header/SearchBar/Personnel.tsx
+++ b/fe/src/components/Header/SearchBar/Personnel.tsx
@@ -1,10 +1,10 @@
-import { usePersonnelDispatch, usePersonnelState } from 'contexts/PersonnelContext';
-
 import { ClickModal } from 'components/Header/SearchBar/';
 import ResetButton from 'components/Header/SearchBar/common/ResetButton';
 import InputButton from 'components/Header/SearchBar/common/InputButton';
 
-function Personnel({ clickModal, isClicked, searchBarFocusModal }: ClickModal) {
+import { usePersonnelDispatch, usePersonnelState } from 'hooks/usePersonnel';
+
+function Personnel({ clickModal }: ClickModal) {
   const { personnelCounterText, counter } = usePersonnelState();
   const { resetCount } = usePersonnelDispatch();
 

--- a/fe/src/components/Header/SearchBar/SearchButton.tsx
+++ b/fe/src/components/Header/SearchBar/SearchButton.tsx
@@ -3,10 +3,10 @@ import {
   StyledSearchIcon,
 } from 'components/Header/SearchBar/searchBar.styled';
 
-import { usePeriodDispatch, usePeriodState } from 'contexts/periodContext';
+import { useModal } from 'hooks/useModal';
+import { usePeriodDispatch, usePeriodState } from 'hooks/usePeriod';
 
 import { mockDate } from 'utils/util';
-import { useModal } from 'hooks/useModal';
 
 function SearchButton() {
   const { searchBarFocusModal, closeModal } = useModal();

--- a/fe/src/components/Header/SearchWrapper.tsx
+++ b/fe/src/components/Header/SearchWrapper.tsx
@@ -1,5 +1,5 @@
-import { Dispatch } from 'react';
 import styled from 'styled-components';
+
 import Menu from 'components/Header/Menu';
 import MiniSearchBar from 'components/Header/SearchBar/MiniSearchBar';
 import SearchBar from 'components/Header/SearchBar/';

--- a/fe/src/components/Header/index.tsx
+++ b/fe/src/components/Header/index.tsx
@@ -1,52 +1,36 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import styled, { css } from 'styled-components';
 import { Link } from '@mui/material';
-import { ReactComponent as LogoImg } from 'images/logo.svg';
 
 import SearchWrapper from 'components/Header/SearchWrapper';
 import UserMenu from 'components/Header/UserMenu';
 
-// type Router = '/' | '/result';
+import { ReactComponent as LogoImg } from 'images/logo.svg';
 
 type Position = {
   position: string;
 };
 
-function Header({ containerRef }: { containerRef: React.RefObject<HTMLDivElement> | null }) {
+function Header() {
   const location = useLocation();
   const path = location.pathname;
 
   const [miniFocus, setMiniFocus] = useState(true);
   const changeSearchBar = (e: React.MouseEvent<HTMLElement>) => setMiniFocus((focus) => !focus);
 
-  const headerRef = useRef<HTMLDivElement>(null);
-  const onClickEvent = ({ target }: MouseEvent) => {
-    if (!miniFocus && !headerRef.current?.contains(target as Node)) {
-      setMiniFocus(true);
-    }
-  };
-
-  // 모달 외부 영역 클릭시 miniSearchbar로 돌아오도록 한다.
-  useEffect(() => {
-    const parentContainer = containerRef?.current;
-
-    // undefind를 반환하지 않으면 가장 마지막에 있는 return 문에서 Arrow function expected no return value. 라는 에러가 뜬다.
-    if (!parentContainer) return undefined;
-    parentContainer.addEventListener('mousedown', onClickEvent);
-
-    return () => parentContainer.removeEventListener('mousedown', onClickEvent);
-  }, [containerRef, miniFocus]);
-
   return (
-    <HeaderWrap position={path} ref={headerRef}>
-      <Link href="/" style={{ height: '26px' }}>
-        <LogoImg aria-label="로고이미지" />
-      </Link>
-      <SearchWrapper changeSearchBar={changeSearchBar} miniFocus={miniFocus} path={path} />
-      <UserMenu />
-    </HeaderWrap>
+    <>
+      <HeaderWrap position={path}>
+        <Link href="/" style={{ height: '26px' }}>
+          <LogoImg aria-label="로고이미지" />
+        </Link>
+        <SearchWrapper changeSearchBar={changeSearchBar} miniFocus={miniFocus} path={path} />
+        <UserMenu />
+      </HeaderWrap>
+      {path === '/result' && !miniFocus && <HeaderOutSide onClick={changeSearchBar} />}
+    </>
   );
 }
 
@@ -70,6 +54,15 @@ const HeaderWrap = styled.header<Position>`
           background: none;
         `};
   z-index: 1;
+`;
+
+const HeaderOutSide = styled.div`
+  width: 100%;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
 `;
 
 export default Header;

--- a/fe/src/components/Header/index.tsx
+++ b/fe/src/components/Header/index.tsx
@@ -35,6 +35,7 @@ function Header() {
 }
 
 const HeaderWrap = styled.header<Position>`
+  z-index: 3;
   display: flex;
   justify-content: space-between;
   position: fixed;
@@ -53,7 +54,6 @@ const HeaderWrap = styled.header<Position>`
       : css`
           background: none;
         `};
-  z-index: 1;
 `;
 
 const HeaderOutSide = styled.div`

--- a/fe/src/components/Header/index.tsx
+++ b/fe/src/components/Header/index.tsx
@@ -9,42 +9,51 @@ import UserMenu from 'components/Header/UserMenu';
 
 import { ReactComponent as LogoImg } from 'images/logo.svg';
 
+import { useModal } from 'hooks/useModal';
+
 type Position = {
   position: string;
 };
 
 function Header() {
+  const { closeModal } = useModal();
+
   const location = useLocation();
   const path = location.pathname;
 
   const [miniFocus, setMiniFocus] = useState(true);
   const changeSearchBar = (e: React.MouseEvent<HTMLElement>) => setMiniFocus((focus) => !focus);
 
+  const clickHeaderOutside = (e: React.MouseEvent<HTMLElement>) => {
+    changeSearchBar(e);
+    closeModal();
+  };
+
   return (
     <>
-      <HeaderWrap position={path}>
-        <Link href="/" style={{ height: '26px' }}>
-          <LogoImg aria-label="로고이미지" />
-        </Link>
-        <SearchWrapper changeSearchBar={changeSearchBar} miniFocus={miniFocus} path={path} />
-        <UserMenu />
-      </HeaderWrap>
-      {path === '/result' && !miniFocus && <HeaderOutSide onClick={changeSearchBar} />}
+      <HeaderContainer position={path}>
+        <HeaderWrap position={path}>
+          <Link href="/" style={{ height: '26px' }}>
+            <LogoImg aria-label="로고이미지" />
+          </Link>
+          <SearchWrapper changeSearchBar={changeSearchBar} miniFocus={miniFocus} path={path} />
+          <UserMenu />
+        </HeaderWrap>
+      </HeaderContainer>
+      {path === '/result' && !miniFocus && <HeaderOutSide onClick={clickHeaderOutside} />}
     </>
   );
 }
 
-const HeaderWrap = styled.header<Position>`
-  z-index: 3;
-  display: flex;
-  justify-content: space-between;
+const HeaderContainer = styled.div<Position>`
+  z-index: 4;
   position: fixed;
   top: 0;
   left: 50%;
   transform: translate(-50%, 0);
-  width: 1440px;
-  margin-bottom: 20px;
-  padding: 24px 32px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
 
   ${({ position }) =>
     position === '/result'
@@ -56,7 +65,16 @@ const HeaderWrap = styled.header<Position>`
         `};
 `;
 
+const HeaderWrap = styled.header<Position>`
+  display: flex;
+  justify-content: space-between;
+  width: 1440px;
+  margin-bottom: 20px;
+  padding: 24px 32px;
+`;
+
 const HeaderOutSide = styled.div`
+  z-index: 3;
   width: 100%;
   height: 100vh;
   position: fixed;

--- a/fe/src/components/Map/index.tsx
+++ b/fe/src/components/Map/index.tsx
@@ -45,15 +45,14 @@ const MapContainer = styled.div`
   height: 90vh;
   background: skyblue;
   position: relative;
-  z-index: -1;
 `;
 
 const MoveMapCheck = styled.div`
+  z-index: 2;
   position: absolute;
   top: 32px;
   left: 50%;
   transform: translate(-50%, 0);
-  z-index: 4;
   width: 212px;
   border-radius: 8px;
   background: ${({ theme }) => theme.colors.white};
@@ -68,10 +67,10 @@ const StyledCheckbox = styled(Checkbox)`
 `;
 
 const MapLevelButtons = styled(ButtonGroup)`
+  z-index: 2;
   position: absolute;
   top: 32px;
   right: 32px;
-  z-index: 4;
 `;
 
 const StyledButton = styled(Button)`

--- a/fe/src/components/Modals/PeriodModal.tsx
+++ b/fe/src/components/Modals/PeriodModal.tsx
@@ -1,7 +1,9 @@
-import { usePeriodState } from 'contexts/periodContext';
-import Calendar from 'components/Calender';
 import styled from 'styled-components';
-import { ModalWrap } from './styled';
+
+import { ModalWrap } from 'components/Modals/styled';
+import Calendar from 'components/Calender';
+
+import { usePeriodState } from 'hooks/usePeriod';
 
 function PeriodModal() {
   const state = usePeriodState();

--- a/fe/src/components/Modals/Personnel/PersonnelCounter.tsx
+++ b/fe/src/components/Modals/Personnel/PersonnelCounter.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 
-import { usePersonnelDispatch, usePersonnelState } from 'contexts/PersonnelContext';
-
 import styled, { css } from 'styled-components';
+import { PersonnselInfo } from 'components/Modals/Personnel/';
+
 import { ReactComponent as PlusIcon } from 'images/FE_숙소예약서비스/Property 1=plus-circle.svg';
 import { ReactComponent as MinusIcon } from 'images/FE_숙소예약서비스/Property 1=minus-circle.svg';
 
-import { PersonnselInfo } from 'components/Modals/Personnel/';
+import { usePersonnelDispatch, usePersonnelState } from 'hooks/usePersonnel';
 
 type InfoProps = {
   info: PersonnselInfo;

--- a/fe/src/components/Modals/Personnel/PersonnelCounter.tsx
+++ b/fe/src/components/Modals/Personnel/PersonnelCounter.tsx
@@ -14,22 +14,24 @@ type InfoProps = {
 
 const [MAX_COUNTER, MIN_COUNTER] = [8, 0];
 
+const makePersonnelText = (personnelInfo: { [key: string]: number }) => {
+  const { adult, child, toddler } = personnelInfo;
+  const guest = adult + child;
+
+  if (!adult && !child && !toddler) {
+    return '인원 선택';
+  }
+
+  if (!toddler) {
+    return `게스트 ${guest}명`;
+  }
+
+  return `게스트 ${guest}명,유아 ${toddler}명`;
+};
+
 function PersonnelModalWrap({ info }: InfoProps) {
   const { counter } = usePersonnelState();
-  const { increaseCount, decreaseCount, setText } = usePersonnelDispatch();
-
-  const makeText = () => {
-    const { adult, child, toddler } = counter;
-    const guest = adult + child;
-    let text;
-
-    if (toddler === 0) {
-      text = `게스트 ${guest}명`;
-    } else {
-      text = `게스트 ${guest}명,유아 ${toddler}명`;
-    }
-    return text;
-  };
+  const { increaseCount, decreaseCount, setPersonnelText } = usePersonnelDispatch();
 
   const increaseCounter = (e: React.MouseEvent<HTMLElement>) => {
     if (counter[info.desc] < MAX_COUNTER) {
@@ -44,7 +46,8 @@ function PersonnelModalWrap({ info }: InfoProps) {
   };
 
   useEffect(() => {
-    setText(makeText());
+    const personnelText = makePersonnelText(counter);
+    setPersonnelText(personnelText);
   }, [counter]);
 
   return (

--- a/fe/src/components/Modals/Reservation/Cost.tsx
+++ b/fe/src/components/Modals/Reservation/Cost.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
-// import { FlexBox } from 'components/Modals/Reservation/';
+import { Divider } from '@mui/material';
 
-import { usePeriodState } from 'contexts/periodContext';
+import { usePeriodState } from 'hooks/usePeriod';
 
 import { toLocalString } from 'utils/helper';
-import { Divider } from '@mui/material';
 
 function CostInfo({ info }: any) {
   const { checkIn, checkOut } = usePeriodState();

--- a/fe/src/components/Modals/Reservation/ReservationInfo.tsx
+++ b/fe/src/components/Modals/Reservation/ReservationInfo.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 import InputButton from 'components/Header/SearchBar/common/InputButton';
 
-import { usePersonnelState } from 'contexts/PersonnelContext';
 import { usePeriodState } from 'hooks/usePeriod';
+import { usePersonnelState } from 'hooks/usePersonnel';
 
 import { makeDateString, mockDate } from 'utils/util';
 

--- a/fe/src/components/Modals/Reservation/ReservationInfo.tsx
+++ b/fe/src/components/Modals/Reservation/ReservationInfo.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 import InputButton from 'components/Header/SearchBar/common/InputButton';
 
-import { usePeriodState } from 'contexts/periodContext';
 import { usePersonnelState } from 'contexts/PersonnelContext';
+import { usePeriodState } from 'hooks/usePeriod';
 
 import { makeDateString, mockDate } from 'utils/util';
 

--- a/fe/src/components/Modals/Reservation/index.tsx
+++ b/fe/src/components/Modals/Reservation/index.tsx
@@ -37,7 +37,7 @@ function Reservation() {
 }
 
 const Background = styled.div`
-  z-index: 4;
+  z-index: 5;
   position: absolute;
   width: 100vw;
   height: 100%;
@@ -45,7 +45,7 @@ const Background = styled.div`
 `;
 
 const ReservationBox = styled.div`
-  z-index: 4;
+  z-index: 5;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/fe/src/components/Modals/Reservation/index.tsx
+++ b/fe/src/components/Modals/Reservation/index.tsx
@@ -37,16 +37,15 @@ function Reservation() {
 }
 
 const Background = styled.div`
+  z-index: 4;
   position: absolute;
   width: 100vw;
   height: 100%;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   background: #333333b3;
 `;
 
 const ReservationBox = styled.div`
+  z-index: 4;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -56,7 +55,6 @@ const ReservationBox = styled.div`
   border-radius: 10px;
   background: white;
   text-align: center;
-  z-index: 5;
 
   .info_caption {
     color: ${({ theme }) => theme.colors.grey2};

--- a/fe/src/components/Modals/Reservation/index.tsx
+++ b/fe/src/components/Modals/Reservation/index.tsx
@@ -39,6 +39,9 @@ function Reservation() {
 const Background = styled.div`
   z-index: 5;
   position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 100vw;
   height: 100%;
   background: #333333b3;

--- a/fe/src/contexts/PersonnelContext.tsx
+++ b/fe/src/contexts/PersonnelContext.tsx
@@ -92,8 +92,8 @@ export function usePersonnelDispatch() {
 
   const increaseCount = (age: string) => dispatch({ type: 'INCREASE_COUNT', age });
   const decreaseCount = (age: string) => dispatch({ type: 'DECREASE_COUNT', age });
-  const setText = (text: string) => dispatch({ type: 'SET_COUNTER_TEXT', text });
+  const setPersonnelText = (text: string) => dispatch({ type: 'SET_COUNTER_TEXT', text });
   const resetCount = () => dispatch({ type: 'RESET_COUNT', payload: null });
 
-  return { increaseCount, decreaseCount, setText, resetCount };
+  return { increaseCount, decreaseCount, setPersonnelText, resetCount };
 }

--- a/fe/src/contexts/PersonnelContext.tsx
+++ b/fe/src/contexts/PersonnelContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, Dispatch, ReactNode, useContext, useReducer } from 'react';
+import { createContext, Dispatch, ReactNode, useReducer } from 'react';
 
 type Counter = {
   [key: string]: number;
@@ -25,8 +25,8 @@ const initState: State = {
   personnelCounterText: '인원 선택',
 };
 
-const PersonnelStateContext = createContext<State | null>(initState);
-const PersonnelDispatchContext = createContext<PersonnelDispatch | null>(null);
+export const PersonnelStateContext = createContext<State | null>(initState);
+export const PersonnelDispatchContext = createContext<PersonnelDispatch | null>(null);
 
 export function PersonnalProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(personnalReducer, initState);
@@ -77,23 +77,4 @@ function personnalReducer(state: State, action: Action) {
     default:
       throw new Error();
   }
-}
-
-export function usePersonnelState() {
-  const state = useContext(PersonnelStateContext);
-  if (!state) throw new Error();
-
-  return { counter: state.counter, personnelCounterText: state.personnelCounterText };
-}
-
-export function usePersonnelDispatch() {
-  const dispatch = useContext(PersonnelDispatchContext);
-  if (!dispatch) throw new Error();
-
-  const increaseCount = (age: string) => dispatch({ type: 'INCREASE_COUNT', age });
-  const decreaseCount = (age: string) => dispatch({ type: 'DECREASE_COUNT', age });
-  const setPersonnelText = (text: string) => dispatch({ type: 'SET_COUNTER_TEXT', text });
-  const resetCount = () => dispatch({ type: 'RESET_COUNT', payload: null });
-
-  return { increaseCount, decreaseCount, setPersonnelText, resetCount };
 }

--- a/fe/src/contexts/periodContext.tsx
+++ b/fe/src/contexts/periodContext.tsx
@@ -22,8 +22,8 @@ type PeriodDispatch = Dispatch<Action>;
 
 const thisDate = new Date();
 
-const PeriodStateContext = createContext<Period | null>(null);
-const PeriodDispatchContext = createContext<PeriodDispatch | null>(null);
+export const PeriodStateContext = createContext<Period | null>(null);
+export const PeriodDispatchContext = createContext<PeriodDispatch | null>(null);
 
 const initialState: Period = {
   date: thisDate,
@@ -77,29 +77,4 @@ function reducer(state: Period, action: Action): Period {
     default:
       throw new Error();
   }
-}
-
-export function usePeriodState() {
-  const state = useContext(PeriodStateContext);
-  if (!state) throw new Error();
-
-  return {
-    checkIn: state.checkInOut.checkIn,
-    checkOut: state.checkInOut.checkOut,
-    date: state.date,
-    periodText: state.periodText,
-  };
-}
-
-export function usePeriodDispatch() {
-  const dispatch = useContext(PeriodDispatchContext);
-  if (!dispatch) throw new Error();
-
-  const setCheckIn = (checkIn: Date) => dispatch({ type: 'SET_CHECK_IN', checkIn });
-  const setCheckOut = (checkOut: Date) => dispatch({ type: 'SET_CHECK_OUT', checkOut });
-  const setDate = (date: Date) => dispatch({ type: 'SET_DATE', date });
-  const resetDate = () => dispatch({ type: 'RESET_DATE', payload: null });
-  const setPeriodText = (text: string) => dispatch({ type: 'SET_TEXT', text });
-
-  return { setCheckIn, setCheckOut, setDate, resetDate, setPeriodText };
 }

--- a/fe/src/contexts/periodContext.tsx
+++ b/fe/src/contexts/periodContext.tsx
@@ -99,7 +99,7 @@ export function usePeriodDispatch() {
   const setCheckOut = (checkOut: Date) => dispatch({ type: 'SET_CHECK_OUT', checkOut });
   const setDate = (date: Date) => dispatch({ type: 'SET_DATE', date });
   const resetDate = () => dispatch({ type: 'RESET_DATE', payload: null });
-  const setText = (text: string) => dispatch({ type: 'SET_TEXT', text });
+  const setPeriodText = (text: string) => dispatch({ type: 'SET_TEXT', text });
 
-  return { setCheckIn, setCheckOut, setDate, resetDate, setText };
+  return { setCheckIn, setCheckOut, setDate, resetDate, setPeriodText };
 }

--- a/fe/src/hooks/usePeriod.tsx
+++ b/fe/src/hooks/usePeriod.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import { PeriodDispatchContext, PeriodStateContext } from 'contexts/periodContext';
+
+export function usePeriodState() {
+  const state = useContext(PeriodStateContext);
+  if (!state) throw new Error();
+
+  return {
+    checkIn: state.checkInOut.checkIn,
+    checkOut: state.checkInOut.checkOut,
+    date: state.date,
+    periodText: state.periodText,
+  };
+}
+
+export function usePeriodDispatch() {
+  const dispatch = useContext(PeriodDispatchContext);
+  if (!dispatch) throw new Error();
+
+  const setCheckIn = (checkIn: Date) => dispatch({ type: 'SET_CHECK_IN', checkIn });
+  const setCheckOut = (checkOut: Date) => dispatch({ type: 'SET_CHECK_OUT', checkOut });
+  const setDate = (date: Date) => dispatch({ type: 'SET_DATE', date });
+  const resetDate = () => dispatch({ type: 'RESET_DATE', payload: null });
+  const setPeriodText = (text: string) => dispatch({ type: 'SET_TEXT', text });
+
+  return { setCheckIn, setCheckOut, setDate, resetDate, setPeriodText };
+}

--- a/fe/src/hooks/usePersonnel.tsx
+++ b/fe/src/hooks/usePersonnel.tsx
@@ -1,0 +1,22 @@
+import { useContext } from 'react';
+
+import { PersonnelDispatchContext, PersonnelStateContext } from 'contexts/PersonnelContext';
+
+export function usePersonnelState() {
+  const state = useContext(PersonnelStateContext);
+  if (!state) throw new Error();
+
+  return { counter: state.counter, personnelCounterText: state.personnelCounterText };
+}
+
+export function usePersonnelDispatch() {
+  const dispatch = useContext(PersonnelDispatchContext);
+  if (!dispatch) throw new Error();
+
+  const increaseCount = (age: string) => dispatch({ type: 'INCREASE_COUNT', age });
+  const decreaseCount = (age: string) => dispatch({ type: 'DECREASE_COUNT', age });
+  const setPersonnelText = (text: string) => dispatch({ type: 'SET_COUNTER_TEXT', text });
+  const resetCount = () => dispatch({ type: 'RESET_COUNT', payload: null });
+
+  return { increaseCount, decreaseCount, setPersonnelText, resetCount };
+}

--- a/fe/src/pages/Layout.tsx
+++ b/fe/src/pages/Layout.tsx
@@ -1,15 +1,15 @@
 import { Outlet } from 'react-router-dom';
-import Header from 'components/Header/index';
+
 import styled from 'styled-components';
+import Header from 'components/Header/index';
+
 import { ModalProvider } from 'contexts/ModalContext';
-import { useRef } from 'react';
 
 function Layout() {
-  const containerRef = useRef<HTMLDivElement>(null);
   return (
     <ModalProvider>
-      <Container ref={containerRef}>
-        <Header containerRef={containerRef} />
+      <Container>
+        <Header />
         <Outlet />
       </Container>
     </ModalProvider>

--- a/fe/src/pages/Layout.tsx
+++ b/fe/src/pages/Layout.tsx
@@ -18,5 +18,6 @@ function Layout() {
 
 const Container = styled.div`
   position: relative;
+  width: 100%;
 `;
 export default Layout;


### PR DESCRIPTION
- 결과 페이지의 큰 서치바 헤더 영역 밖 클릭시 작은 서치바로 돌아오는 기능 수정 
    - 더이상 addEventListner를 사용하지 않씁니다 그런데 약간 편법을 곁들인...
    - 큰 서치바일때 헤더 영역 밑 전체를 덮는 div가 생깁니다 그래서 그걸 클릭하면 닫히도록 했어요 ㅎㅎ
- 기간, 인원 context 안에 있던 hook을 파일로 따로 분리했습니다.
- 지도, 헤더, 모달들의 z-index를 수정했습니다